### PR TITLE
Refactor/back button styling

### DIFF
--- a/src/Components/Error/Error.css
+++ b/src/Components/Error/Error.css
@@ -1,3 +1,7 @@
+.error-photo {
+  height: 300px;
+}
+
 .error-msg {
     min-height: 88.3vh;
     display: flex;
@@ -10,7 +14,7 @@
     margin-top: 5vh;
   }
   
-  .back-button {
+  .home-link {
     height: 12.5vh;
     width: 40vw;
     font-size: 6vh;
@@ -26,7 +30,7 @@
     margin-top: 5vh;
   }
   
-  .back-button:hover {
+  .home-link:hover {
     background-color: hsla(229, 99%, 50%, 0.5);
     color: black;
     border-radius: 5px;

--- a/src/Components/Error/Error.tsx
+++ b/src/Components/Error/Error.tsx
@@ -13,6 +13,7 @@ type ErrorProps = {
 
   return (
     <div className='error-msg'>
+      <img className="error-photo" src='https://media.npr.org/assets/img/2016/03/29/ap_090911089838_sq-3271237f28995f6530d9634ff27228cae88e3440.jpg' alt='Photo of Shaquille ONeal crying' />
   <h2>Uh-oh...That's an airball!</h2>
   <h2>
     {!props.message 
@@ -23,7 +24,7 @@ type ErrorProps = {
   </h2>
   <NavLink to='/' className='nav'>
     <div onClick={handleReset}>
-      <button className='back-button'>RosterWatch Home</button>
+      <button className='home-link'>RosterWatch Home</button>
     </div>
   </NavLink>
 </div>

--- a/src/Components/SelectedTeam/SelectedTeam.css
+++ b/src/Components/SelectedTeam/SelectedTeam.css
@@ -1,19 +1,15 @@
-h2, ul {
+ul {
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
   
 .roster-header {
-  top: 0;
-  left: 0;
-  margin: 10px;
+  margin-top: 15px;
   font-size: 55px;
   -webkit-text-stroke: 3px #1D428A;
   -webkit-text-fill-color: rgb(245, 189, 50);
-  font-family: helvetica;
-  margin-left: 30px;
-  margin-bottom: 10px;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 .roster-container {
@@ -35,7 +31,7 @@ h2, ul {
   font-size: 25px;
   border: solid blue;
   border-radius: 10px;
-  background-color: rgba(211, 211, 211, 0.631);
+  background-color:rgba(128, 128, 128, 0.639);
 }
 
 p {
@@ -50,7 +46,6 @@ p {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-
 }
   
 .player {
@@ -83,5 +78,9 @@ p {
 
 .back-button {
   height: 60px;
-  margin-top: 10px;
+  margin-bottom: 15px;
+}
+
+.back-button:hover {
+  height: 75px;
 }

--- a/src/Components/SelectedTeam/SelectedTeam.tsx
+++ b/src/Components/SelectedTeam/SelectedTeam.tsx
@@ -21,7 +21,6 @@ const SelectedTeam = () => {
     const [error, setError] = useState<string | null>(null)
     const selectedTeamLogo: NBALogoType | undefined  = nbaLogos.find((team) => {
       if (team.id === teamId) {
-        console.log('find team: ', team)
         return team
       }
     })

--- a/src/Components/TeamCard/TeamCard.css
+++ b/src/Components/TeamCard/TeamCard.css
@@ -5,7 +5,13 @@
   display: flex;
   align-items: center;
   justify-content: space-evenly;
-  background-color: grey;
+  background-color: rgba(128, 128, 128, 0.639);
+}
+
+.team-card:hover {
+  height: 90px;
+  width: 265px;
+  border: 4px solid rgb(245, 189, 50);
 }
 
 .team-logo {

--- a/src/Components/TeamCard/TeamCard.tsx
+++ b/src/Components/TeamCard/TeamCard.tsx
@@ -25,7 +25,7 @@ const TeamCard = ({id, abbreviation, city, conference, division, full_name, name
     <div className="team-card">
       <img className="team-logo" src={`${individualLogo?.logo}`} alt={`${full_name} logo`} />
       <div className="team-name">
-        <h3>{city} {name}</h3>
+        <h2>{city} {name}</h2>
       </div>
     </div>
    </Link>   


### PR DESCRIPTION
## Pull Request

## Description
Changed some styling so that it matches on both pages and also because of lighthouse accessibility failures.

## Changes Made
 -Add photo that populates on the error page and styling
-edit rules to match backgrounds of home page and selected team page.
-Add a hover rule as well as change the background color
-Change '.back-button' to '.home-link' for error page because we already have ".back-button" in the selected team page
-cleaned up spacing
-changed h3 to h2 for cards team names because of accessibility. We have to go in order.

## Reviewer
@Averyberryman @ganuza 

## Additional Notes
 Add any additional notes, comments, or questions you have.